### PR TITLE
Use field constraint when generating pydantic class

### DIFF
--- a/swagger2pydantic.py
+++ b/swagger2pydantic.py
@@ -88,6 +88,7 @@ def create_model(model_file_name: str):
         disable_timestamp=True,
         enum_field_as_literal=LiteralType.All,
         use_double_quotes=True,
+        field_constraints=True,
     )
     LOGGER.info(f"Wrote model to file {model_file_name}")
 


### PR DESCRIPTION
This ensure the generated file passes type checking
