### PR TITLE
Ruff update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ runs:
       run: python model_generator/swagger2pydantic.py
       shell: bash
     - name: Upgrade syntax
-      run: ruff $MODEL_FILE --fix
+      run: ruff check $MODEL_FILE --fix --unsafe-fixes
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 line-length = 79
 
 [tool.ruff]
-select = ["F401", "I", "UP"]
+lint.select = ["F401", "I", "UP"]
 line-length = 79
 target-version = "py39"
 
-[tool.ruff.pyupgrade]
+[tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true


### PR DESCRIPTION
As some necessary fixes for linter warnings became "unsafe", we needed to have an additional flag.

See https://docs.astral.sh/ruff/rules/non-pep585-annotation/